### PR TITLE
Github PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+# What it does
+
+> Briefly describe what's the objective of this PR.
+
+## - Changes
+
+> Describe everything that has changed, or was added/updated/deleted.
+
+## - How to test it?
+
+-   Describe every step necessary to test it
+-   Including commands, environment variables and scenarios
+
+## - TODOs
+
+-   [ ] Tests
+-   [ ] Documentation
+-   [ ] Technical Debt
+
+# Involved risks
+
+> Describe here all the risks envolving infrastructure, functionality or business


### PR DESCRIPTION
# What it does

- Add template to github's PRs

## - Changes

- Previously, no format was provided, so contributors couldn't know for sure what and how to write PRs to this work.

## - How to test it?

- Open a new PR and this format should up automatically, indicating how to fill it.

## - TODOs

-   [x] Tests
-   [x] Documentation
-   [x] Technical Debt

# Involved risks

None
